### PR TITLE
Various fixes and improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,23 @@ cache:
 
 before_install:
   - git clone https://github.com/bitcoin-core/secp256k1.git
-  - sudo apt-add-repository ppa:bitcoin/bitcoin -y
   - sudo apt-get update
   - mkdir bin
+  - wget https://bitcoincore.org/bin/bitcoin-core-0.20.0/bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
+  - echo "35ec10f87b6bc1e44fd9cd1157e5dfa483eaf14d7d9a9c274774539e7824c427  bitcoin-0.20.0-x86_64-linux-gnu.tar.gz" | sha256sum --check
+  - tar -xzvf bitcoin-0.20.0-x86_64-linux-gnu.tar.gz
+  - mv ./bitcoin-0.20.0/bin/bitcoind ./bin/bitcoind
   - wget https://download.bitcoinabc.org/0.18.5/linux/bitcoin-abc-0.18.5-x86_64-linux-gnu.tar.gz
+  - echo "11439fcdae421ae96d2a7ddc3d43c9c284af44716cb5f363c61e53885a5a8811  bitcoin-abc-0.18.5-x86_64-linux-gnu.tar.gz" | sha256sum --check
   - tar -xzvf bitcoin-abc-0.18.5-x86_64-linux-gnu.tar.gz
   - mv ./bitcoin-abc-0.18.5/bin/bitcoind ./bin/bitcoin-cash
+  - wget https://download.litecoin.org/litecoin-0.18.1/linux/litecoin-0.18.1-x86_64-linux-gnu.tar.gz
+  - echo "ca50936299e2c5a66b954c266dcaaeef9e91b2f5307069b9894048acf3eb5751  litecoin-0.18.1-x86_64-linux-gnu.tar.gz" | sha256sum --check
+  - tar -xzvf litecoin-0.18.1-x86_64-linux-gnu.tar.gz
+  - mv ./litecoin-0.18.1/bin/litecoind ./bin/litecoind
 
 install:
-  - sudo apt-get install build-essential automake pkg-config libtool libgmp-dev bitcoind -y
+  - sudo apt-get install build-essential automake pkg-config libtool libgmp-dev -y
   - pip install -r requirements.txt
   - cd secp256k1
   - ./autogen.sh
@@ -29,7 +37,8 @@ install:
   - export LD_LIBRARY_PATH
 
 script:
-  - python generate_chain.py --output-dir=.output --chain=btc
+  - python generate_chain.py --output-dir=.output --chain=btc --exec=./bin/bitcoind
   - python generate_chain.py --output-dir=.output --chain=bch --exec=./bin/bitcoin-cash
+  - python generate_chain.py --output-dir=.output --chain=ltc --exec=./bin/litecoind
   - cd tests && pytest
 

--- a/bitcoin.conf
+++ b/bitcoin.conf
@@ -2,3 +2,4 @@ server=1
 regtest=1
 rpcuser=rpcuser
 rpcpassword=rpcpassword
+dustrelayfee=0

--- a/runall.sh
+++ b/runall.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-python3 generate_chain.py --output-dir=output
+python3 generate_chain.py --output-dir=output --chain=btc --exec=./bin/bitcoind
 python3 generate_chain.py --output-dir=output --chain=bch --exec=./bin/bitcoin-cash
 python3 generate_chain.py --output-dir=output --chain=ltc --exec=./bin/litecoind


### PR DESCRIPTION
Improvements:

1. Use a prefix for the temp folders.
2. When starting the node, wait for the RPC to be ready. Results if faster start of the script.
3. When terminating the node, wait of the process to finish (kills it after a timeout). Results in faster termination of the script.

Fix crash in latest bitcoind:

When running the latest bitcoin 0.20.0, the script
crashes when "Creating output with 0 BTC" because
the node rejects the "dust" transaction.

Fix travis tests