### PR TITLE
Fixes #5. Creates wallet on startup

### DIFF
--- a/testchain/address.py
+++ b/testchain/address.py
@@ -37,7 +37,7 @@ class Address(object):
             self.address = P2WSHBitcoinAddress.from_scriptPubKey(script_pub_key)
         else:
             raise UnsupportedAddressTypeError()
-        self.value = 0
+        self.value = 0.0
         self.txid = None
         self.vout = None
 

--- a/testchain/runner.py
+++ b/testchain/runner.py
@@ -34,6 +34,7 @@ class Runner(object):
         self._setup_chain_params()
         self._setup_bitcoind()
         self.proxy = bitcointx.rpc.Proxy(btc_conf_file=self.conf_file)
+        self.proxy.call("createwallet", os.path.join(self.tempdir.name, "testwallet"))
         self.proxy.call("importprivkey", COINBASE_KEY)
 
     def _setup_logger(self):


### PR DESCRIPTION
As described in issue #5 recent Bitcoin version do not create wallets on default.

Also in this PR is a commit which initialized the value field to a float type.  